### PR TITLE
Not pass nil to regexp-quote

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -266,7 +266,7 @@
   :group 'helm-swoop :type 'function)
 
 (defun helm-swoop-pre-input-optimize ($query)
-  (regexp-quote $query))
+  (when $query (regexp-quote $query)))
 
 (defsubst helm-swoop--goto-line ($line)
   (goto-char (point-min))


### PR DESCRIPTION
I found at #155
This fix below error.

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  regexp-quote(nil)
  helm-swoop-pre-input-optimize(nil)
  helm-swoop()
```