### PR TITLE
remove file encoding specification

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -1,4 +1,4 @@
-;;; helm-swoop.el --- Efficiently hopping squeezed lines powered by helm interface -*- coding: utf-8; lexical-binding: t -*-
+;;; helm-swoop.el --- Efficiently hopping squeezed lines powered by helm interface -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 - 2018 by Shingo Fukuyama
 


### PR DESCRIPTION
There're no `multi-byte` characters and we indend to use ASCII only.
So we can remove useless encodhing specification.