### PR TITLE
feat: Add `swiper`-like font lock ensure mechanism.

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -174,6 +174,15 @@
           (const :tag "Pulse highlight function" pulse-momentary-highlight-region)
           function))
 
+(defcustom helm-swoop-fontify-buffer-size-limit 100000
+  "If buffer size smaller than value, do fontify to make buffer highlighted.
+
+If value is symbol `always', always do fontify."
+  :group 'helm-swoop
+  :type '(choice
+          integer
+          (const :tag "Always Fontify" always)))
+
 (defvar helm-swoop-candidate-number-limit 19999)
 (defvar helm-swoop-buffer "*Helm Swoop*")
 (defvar helm-swoop-prompt "Swoop: ")
@@ -558,7 +567,8 @@ This function needs to call after latest helm-swoop-line-overlay set."
     (when (and helm-swoop-speed-or-color
                font-lock-mode
                fontify-safe?
-               (< (buffer-size) 100000))
+               (or (eq 'always helm-swoop-fontify-buffer-size-limit)
+                   (< (buffer-size) helm-swoop-fontify-buffer-size-limit)))
       (if (fboundp 'font-lock-ensure)
           (font-lock-ensure)
         (with-no-warnings (font-lock-fontify-buffer))))))

--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -552,9 +552,7 @@ If $linum is number, lines are separated by $linum"
                       (setq helm-swoop-list-cache
                             (helm-swoop--get-content helm-swoop-target-buffer t))
                       "\n" helm-swoop-last-prefix-number)))
-    (get-line . ,(if helm-swoop-speed-or-color
-                     'helm-swoop--buffer-substring
-                   'buffer-substring-no-properties))
+    (get-line . ,#'helm-swoop--buffer-substring)
     (keymap . ,helm-swoop-map)
     (header-line . ,(substitute-command-keys
                      "[\\<helm-swoop-map>\\[helm-swoop-edit]] Edit mode, \


### PR DESCRIPTION
Emacs's font-lock is lazy. when `helm-swoop` get contents from buffer, it may be
not being fontified. So we force emacs to do it.

But in some buffers, `font-lock-ensure` will break properties in original
buffer, so we need to exclude them in `helm-swoop-font-lock-exclude`.

Close #85.