### PR TITLE
Add GitHub Actions configure files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Main workflow
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - '24.4'
+          - '24.5'
+          - '25.1'
+          - '25.2'
+          - '25.3'
+          - '26.1'
+          - '26.2'
+          - '26.3'
+          - 'snapshot'
+        include:
+          - emacs_version: 'snapshot'
+            allow_failure: true
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1.1.1
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+    - uses: conao3/setup-cask@master
+
+    - name: Run tests
+      if: matrix.allow_failure != true
+      run: 'make test'
+
+    - name: Run tests (allow failure)
+      if: matrix.allow_failure == true
+      run: 'make test || true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-*.DS_Store
+## .gitignore
+
+*-autoloads.el
 *.elc
+/.cask

--- a/Cask
+++ b/Cask
@@ -1,0 +1,9 @@
+;; -*- mode:lisp -*-
+
+(source gnu)
+(source melpa)
+
+(package-file "helm-swoop.el")
+
+(development
+ (depends-on "buttercup"))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+## Makefile
+
+# Copyright (C) 2019  Naoya Yamashita
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+all:
+
+REPO_USER    := emacsorphanage
+PACKAGE_NAME := helm-swoop
+REPO_NAME    := helm-swoop
+
+EMACS        ?= emacs
+ELS          := $(shell cask files)
+
+GIT_HOOKS    := pre-commit
+
+##################################################
+
+.PHONY: all help build test clean
+
+all: help
+
+help:
+	$(info )
+	$(info Commands)
+	$(info ========)
+	$(info   - make          # Show this message)
+	$(info   - make build    # Compile Elisp files)
+	$(info   - make test     # Compile Elisp files and test $(PACKAGE_NAME))
+	$(info )
+	$(info Cleaning)
+	$(info ========)
+	$(info   - make clean    # Clean compiled files)
+	$(info )
+	$(info This Makefile required `cask`)
+	$(info See https://github.com/$(REPO_USER)/$(REPO_NAME)#contribution)
+	$(info )
+
+##############################
+
+%.elc: %.el .cask
+	cask exec $(EMACS) -Q --batch -f batch-byte-compile $<
+
+.cask: Cask
+	cask install
+	touch $@
+
+##############################
+
+build: $(ELS:%.el=%.elc)
+
+test: build
+	cask exec buttercup -L .
+
+clean:
+	rm -rf $(ELS:%.el=%.elc) .cask

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![melpa badge][melpa-badge]][melpa-link] [![melpa stable badge][melpa-stable-badge]][melpa-stable-link]
+[![melpa badge][melpa-badge]][melpa-link]
+[![melpa stable badge][melpa-stable-badge]][melpa-stable-link]
+[![github actions badge][github-actions-badge]][github-actions-link]
 
 List match lines to another buffer, which is able to squeeze by any words you input. At the same time, the original buffer's cursor is jumping line to line according to moving up and down the line list.
 
@@ -176,12 +178,31 @@ i.e.
 
 [helm.el](https://github.com/emacs-helm/helm)
 
+### Contribution
+We welcome PR!
+
+#### Require tools for testing
+- cask
+  - install via brew
+      ```
+      brew install cask
+      ```
+
+  - manual install
+      ```
+      cd ~/
+      hub clone cask/cask
+      export PATH="$HOME/.cask/bin:$PATH"
+      ```
+
 ### License
 > General Public License Version 3 (GPLv3)
 > Copyright (c) Emacsorphanage - https://github.com/emacsorphanage
 > https://www.gnu.org/licenses/gpl-3.0.html
 
 [melpa-link]: http://melpa.org/#/helm-swoop
-[melpa-stable-link]: http://stable.melpa.org/#/helm-swoop
 [melpa-badge]: http://melpa.org/packages/helm-swoop-badge.svg
+[melpa-stable-link]: http://stable.melpa.org/#/helm-swoop
 [melpa-stable-badge]: http://stable.melpa.org/packages/helm-swoop-badge.svg
+[github-actions-link]: https://github.com/emacsorphanage/helm-swoop/actions
+[github-actions-badge]: https://github.com/emacsorphanage/helm-swoop/workflows/Main%20workflow/badge.svg

--- a/tests/helm-swoop-test.el
+++ b/tests/helm-swoop-test.el
@@ -1,0 +1,42 @@
+;;; helm-swoop-test.el --- Test definitions for helm-swoop  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019  Helm-Swoop Community
+
+;; Author: Naoya Yamashita <conao3@gmail.com>
+;; License: GPL-3.0
+;; Homepage: https://github.com/emacsorphanage/helm-swoop
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Test definitions for `helm-swoop'.
+
+
+;;; Code:
+
+(require 'buttercup)
+(require 'helm-swoop)
+
+(describe "A suite"
+  (it "contains a spec with an expectation"
+    (expect t :to-be t)))
+
+;; (provide 'helm-swoop-test)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
+;;; helm-swoop-test.el ends here


### PR DESCRIPTION
This replaces #153.

Add CI via GitHub Actions.
This CI working my fork [like that](https://github.com/conao3/helm-swoop/commit/701c0f33b1045e70a8233b4981ca965ac5f6c887/checks?check_suite_id=372942469).