### PR TITLE
Fix package-lint/checkdoc/byte-compiler warnings

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -8,7 +8,7 @@
 ;; URL: https://github.com/emacsorphanage/helm-swoop
 ;; Created: Oct 24 2013
 ;; Keywords: convenience, helm, swoop, inner, buffer, search
-;; Package-Requires: ((helm "3.2") (emacs "24.4"))
+;; Package-Requires: ((emacs "24.4") (helm "3.2"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@
 ;;; Commentary:
 
 ;; List the all lines to another buffer, which is able to squeeze
-;; by any words you input. At the same time, the original buffer's
+;; by any words you input.  At the same time, the original buffer's
 ;; cursor is jumping line to line according to moving up and down
 ;; the list.
 
@@ -57,7 +57,7 @@
 ;; ;; If this value is t, split window inside the current window
 ;; (setq helm-swoop-split-with-multiple-windows nil)
 
-;; ;; Split direction. 'split-window-vertically or 'split-window-horizontally
+;; ;; Split direction.  'split-window-vertically or 'split-window-horizontally
 ;; (setq helm-swoop-split-direction 'split-window-vertically)
 
 ;; ;; If nil, you can slightly boost invoke speed in exchange for text color
@@ -86,7 +86,7 @@
 
 ;; Helm Swoop Edit
 ;; While doing helm-swoop, press keybind [C-c C-e] to move to edit buffer.
-;; Edit the list and apply by [C-x C-s]. If you'd like to cancel, [C-c C-g]
+;; Edit the list and apply by [C-x C-s].  If you'd like to cancel, [C-c C-g]
 
 ;;; Code:
 
@@ -125,19 +125,19 @@
   :group 'helm-swoop)
 
 (defcustom helm-swoop-speed-or-color nil
-  "If nil, you can slightly boost invoke speed in exchange for text color"
+  "If nil, you can slightly boost invoke speed in exchange for text color."
   :group 'helm-swoop :type 'boolean)
 (defcustom helm-swoop-use-line-number-face nil
-  "Use face to line numbers on helm-swoop buffer"
+  "Use face to line numbers on helm-swoop buffer."
   :group 'helm-swoop :type 'boolean)
 (defcustom helm-swoop-split-with-multiple-windows nil
-  "Split window when having multiple windows open"
+  "Split window when having multiple windows open."
   :group 'helm-swoop :type 'boolean)
 (defcustom helm-swoop-move-to-line-cycle t
-  "Return to the opposite side of line"
+  "Return to the opposite side of line."
   :group 'helm-swoop :type 'boolean)
 (defcustom helm-swoop-split-direction 'split-window-vertically
-  "Split direction"
+  "Split direction."
   :type '(choice (const :tag "vertically"   split-window-vertically)
                  (const :tag "horizontally" split-window-horizontally))
   :group 'helm-swoop)
@@ -156,14 +156,14 @@
         (funcall helm-swoop-split-direction)))
     (other-window 1)
     (switch-to-buffer $buf))
-  "Change the way to split window only when `helm-swoop' is calling")
+  "Change the way to split window only when `helm-swoop' is calling.")
 
 (defcustom helm-swoop-after-goto-line-action-hook nil
-  "hooks run after `helm-swoop--goto-line"
+  "The hook run after `helm-swoop--goto-line."
   :group 'helm-swoop
   :type 'hook)
 (defcustom helm-swoop-before-goto-line-action-hook nil
-  "hooks run before `helm-swoop--goto-line"
+  "The hook run before `helm-swoop--goto-line."
   :group 'helm-swoop
   :type 'hook)
 
@@ -199,11 +199,11 @@ If value is symbol `always', always do fontify."
 
 ;; Global variables
 (defvar helm-swoop-synchronizing-window nil
-  "Window object where `helm-swoop' called from")
+  "Window object where `helm-swoop' called from.")
 (defvar helm-swoop-target-buffer nil
-  "Buffer object where `helm-swoop' called from")
+  "Buffer object where `helm-swoop' called from.")
 (defvar helm-swoop-line-overlay nil
-  "Overlay object to indicate other window's line")
+  "Overlay object to indicate other window's line.")
 
 (defvar helm-swoop--basic-map
   (let ((map (make-sparse-keymap)))
@@ -230,7 +230,7 @@ If value is symbol `always', always do fontify."
     (define-key $map (kbd "C-w") 'helm-swoop-yank-thing-at-point)
     (define-key $map (kbd "^") 'helm-swoop-caret-match)
     $map)
-  "Keymap for helm-swoop")
+  "Keymap for helm-swoop.")
 
 (defvar helm-multi-swoop--basic-map
   (let ((map (make-sparse-keymap)))
@@ -319,31 +319,37 @@ If value is symbol `always', always do fontify."
   "List of major-modes that are incompatible with `font-lock-ensure'.")
 
 (defun helm-swoop-match-functions ()
+  "Return match functions."
   (if helm-swoop-use-fuzzy-match
       (append helm-c-source-swoop-match-functions '(helm-fuzzy-match))
     helm-c-source-swoop-match-functions))
 
 (defun helm-swoop-search-functions ()
+  "Return search functions."
   (if helm-swoop-use-fuzzy-match
       (append helm-c-source-swoop-search-functions '(helm-fuzzy-search))
     helm-c-source-swoop-search-functions))
 
 (defcustom helm-swoop-pre-input-function
   (lambda () (thing-at-point 'symbol))
-  "This function can pre-input keywords when helm-swoop invoked"
+  "This function can pre-input keywords when helm-swoop invoked."
   :group 'helm-swoop :type 'function)
 
 (defun helm-swoop-pre-input-optimize ($query)
+  "Return $QUERY processed by `regexp-quote'."
   (when $query (regexp-quote $query)))
 
 (defsubst helm-swoop--goto-line ($line)
+  "Go to $LINE concider narrowing."
   (goto-char (point-min))
   (forward-line (1- $line)))
 
 (defsubst helm-swoop--recenter ()
+  "Recenter."
   (recenter (/ (window-height) 2)))
 
 (defsubst helm-swoop--delete-overlay ($identity &optional $beg $end)
+  "Delete overlay if $IDENTITY has in $BEG to $END."
   (overlay-recenter (or $end (point-max)))
   (mapc (lambda ($o)
           (if (overlay-get $o $identity)
@@ -351,9 +357,11 @@ If value is symbol `always', always do fontify."
         (overlays-in (or $beg (point-min)) (or $end (point-max)))))
 
 (defsubst helm-swoop--get-string-at-line ()
+  "Get line string with no properties."
   (buffer-substring-no-properties (point-at-bol) (point-at-eol)))
 
 (defun helm-swoop--buffer-substring ($point-min $point-max)
+  "Get buffer substring $POINT-MIN to $POINT-MAX."
   (if helm-swoop-speed-or-color
       (let (($content (buffer-substring $point-min $point-max)))
         (propertize $content 'read-only nil))
@@ -361,7 +369,8 @@ If value is symbol `always', always do fontify."
 
 ;;;###autoload
 (defun helm-swoop-back-to-last-point (&optional $cancel)
-  "Go back to last position where `helm-swoop' was called"
+  "Go back to last position where `helm-swoop' was called.
+If $CANSEL is non-nil, store `helm-swoop-last-point'."
   (interactive)
   (if helm-swoop-last-point
       (let (($po (point)))
@@ -372,7 +381,7 @@ If value is symbol `always', always do fontify."
                 (cons $po (buffer-name (current-buffer))))))))
 
 (defun helm-swoop--split-lines-by ($string $regexp $step)
-  "split-string by $step for multiline"
+  "Return $STRING processed by `split-string' by $step for multiline."
   (or $step (setq $step 1))
   (let (($from1 0) ;; last match point
         ($from2 0) ;; last substring point
@@ -391,7 +400,7 @@ If value is symbol `always', always do fontify."
     (nreverse $list)))
 
 (defun helm-swoop--target-line-overlay-move (&optional $buf)
-  "Add color to the target line"
+  "Add color to the target line in $BUF."
   (move-overlay
    helm-swoop-line-overlay
    (progn
@@ -408,6 +417,7 @@ If value is symbol `always', always do fontify."
   (helm-swoop--unveil-invisible-overlay))
 
 (defun helm-swoop--validate-regexp (regexp)
+  "Validate REGEXP."
   (condition-case _err
       (progn
         (string-match-p regexp "")
@@ -415,6 +425,7 @@ If value is symbol `always', always do fontify."
     (invalid-regexp nil)))
 
 (defun helm-swoop--target-word-overlay ($identity &optional $threshold)
+  "Target ward overlay to $IDENTITY with $THRESHOLD."
   (interactive)
   (save-excursion
     (let (($pat (split-string helm-pattern " "))
@@ -439,6 +450,7 @@ If value is symbol `always', always do fontify."
             $pat))))
 
 (defun helm-swoop--restore-unveiled-overlay ()
+  "Restore unveiled overlay."
   (when helm-swoop-invisible-targets
     (mapc (lambda ($ov) (overlay-put (car $ov) 'invisible (cdr $ov)))
           helm-swoop-invisible-targets)
@@ -460,6 +472,7 @@ This function needs to call after latest helm-swoop-line-overlay set."
 ;; helm action ------------------------------------------------
 
 (defun helm-swoop--move-line-action ()
+  "Move line action."
   (with-helm-window
     (let* (($key (helm-swoop--get-string-at-line))
            ($num (when (string-match "^[0-9]+" $key)
@@ -476,7 +489,7 @@ This function needs to call after latest helm-swoop-line-overlay set."
               (cons helm-swoop-target-buffer $num))))))
 
 (defun helm-swoop--nearest-line ($target $list)
-  "Return the nearest number of $target out of $list."
+  "Return the nearest number of $TARGET out of $LIST."
   (when (and $target $list)
     (let ($result)
       (cl-labels ((filter ($fn $elem $list)
@@ -505,6 +518,7 @@ This function needs to call after latest helm-swoop-line-overlay set."
       $result)))
 
 (defun helm-swoop--keep-nearest-position ()
+  "Keep nearest position."
   (with-helm-window
     (let (($p (point-min)) $list $bound
           $nearest-line $target-point
@@ -536,7 +550,7 @@ This function needs to call after latest helm-swoop-line-overlay set."
           (helm-multi-swoop--move-line-action))))))
 
 (defun helm-swoop--pattern-match ()
-  "Overlay target words"
+  "Overlay target words."
   (with-helm-window
     (setq helm-swoop-pattern helm-pattern)
     (when (< helm-swoop-min-overlay-length (length helm-pattern))
@@ -547,6 +561,7 @@ This function needs to call after latest helm-swoop-line-overlay set."
         (helm-swoop--target-word-overlay 'target-buffer helm-swoop-min-overlay-length)))))
 
 (defun helm-swoop-flash-word ($match-beg $match-end)
+  "Flash ward in $MATCH-BEG to $MATCH-END."
   (interactive)
   (unwind-protect
       (let (($o (make-overlay $match-beg $match-end)))
@@ -575,8 +590,8 @@ This function needs to call after latest helm-swoop-line-overlay set."
         (with-no-warnings (font-lock-fontify-buffer))))))
 
 (defun helm-swoop--get-content ($buffer &optional $linum)
-  "Get the whole content in buffer and add line number at the head.
-If $linum is number, lines are separated by $linum"
+  "Get the whole content in $BUFFER and add line number at the head.
+If $LINUM is number, lines are separated by $LINUM."
   (let (($buf (get-buffer $buffer)))
     (when $buf
       (with-current-buffer $buf
@@ -600,6 +615,7 @@ If $linum is number, lines are separated by $linum"
             (helm-swoop--buffer-substring (point-min) (point-max))))))))
 
 (defun helm-swoop--goto-line-action ($line)
+  "Goto $LINE action."
   (run-hooks 'helm-swoop-before-goto-line-action-hook)
   (helm-swoop--goto-line
    (when (string-match "^[0-9]+" $line)
@@ -617,6 +633,7 @@ If $linum is number, lines are separated by $linum"
   (helm-swoop--recenter))
 
 (defun helm-c-source-swoop ()
+  "C source swoop."
   `((name . ,(buffer-name helm-swoop-target-buffer))
     (candidates . ,(if helm-swoop-list-cache
                        (progn
@@ -640,6 +657,7 @@ If $linum is number, lines are separated by $linum"
     (search . ,(helm-swoop-search-functions))))
 
 (defun helm-c-source-multi-swoop ($buf $func $action $multiline)
+  "C source multi swoop in $BUF for $FUNC, $ACTION, $MULTILINE."
   `((name . ,$buf)
     (candidates . ,(funcall $func))
     (action . ,$action)
@@ -655,30 +673,37 @@ If $linum is number, lines are separated by $linum"
     (search . ,(helm-swoop-search-functions))))
 
 (defun helm-swoop--set-prefix ($multiline)
+  "Set prefix $MULTILINE."
   ;; Enable scrolling margin
   (setq helm-swoop-last-prefix-number
         (or $multiline 1))) ;; $multiline is for resume
 
 ;; Delete cache when buffer is saved or file changes on disk
 (defun helm-swoop--clear-cache ()
+  "Delete cache when buffer is saved or file change on disk."
   (if (boundp 'helm-swoop-list-cache) (setq helm-swoop-list-cache nil)))
 (add-hook 'after-save-hook 'helm-swoop--clear-cache)
 (add-hook 'after-revert-hook 'helm-swoop--clear-cache)
 
 (defadvice narrow-to-region (around helm-swoop-advice-narrow-to-region activate)
+  "Advice for `narrow-to-region'."
   (helm-swoop--clear-cache)
   ad-do-it)
 (defadvice narrow-to-defun (around helm-swoop-advice-narrow-to-defun activate)
+  "Advice for `narrow-to-defun'."
   (helm-swoop--clear-cache)
   ad-do-it)
 (defadvice narrow-to-page (around helm-swoop-advice-narrow-to-page activate)
+  "Advice for `narrow-to-page'."
   (helm-swoop--clear-cache)
   ad-do-it)
 (defadvice widen (around helm-swoop-advice-widen activate)
+  "Advice for `widen'."
   (helm-swoop--clear-cache)
   ad-do-it)
 
 (defun helm-swoop--restore ()
+  "Restore."
   (when (= 1 helm-exit-status)
     (helm-swoop-back-to-last-point t)
     (helm-swoop--restore-unveiled-overlay))
@@ -782,7 +807,7 @@ If $linum is number, lines are separated by $linum"
 
 ;; Receive word from evil search ---------------
 (defun helm-swoop-from-evil-search ()
-  "Invoke `helm-swoop' from evil isearch"
+  "Invoke `helm-swoop' from evil isearch."
   (interactive)
   (if (string-match "\\(isearch-\\|evil.*search\\)" (symbol-name real-last-command))
       (helm-swoop :$query (if isearch-regexp
@@ -811,8 +836,7 @@ If $linum is number, lines are separated by $linum"
 ;; For helm-resume ------------------------
 (defadvice helm-resume-select-buffer
     (around helm-swoop-if-selected-as-resume activate)
-  "Resume if *Helm Swoop* buffer selected as a resume
- when helm-resume with prefix"
+  "Resume if *Helm Swoop* buffer selected when helm-resume with prefix."
   (if (boundp 'helm-swoop-last-query)
       ad-do-it
     ;; If the buffer hasn't called helm-swoop, just hide from options
@@ -825,7 +849,7 @@ If $linum is number, lines are separated by $linum"
     (setq ad-return-value nil)))
 
 (defadvice helm-resume (around helm-swoop-resume activate)
-  "Resume if the last used helm buffer is helm-swoop-buffer"
+  "Resume if the last used helm buffer is helm-swoop-buffer."
   (if (equal helm-last-buffer helm-swoop-buffer)
       (if (boundp 'helm-swoop-last-query)
           (if (not (ad-get-arg 0))
@@ -837,11 +861,13 @@ If $linum is number, lines are separated by $linum"
 
 ;; For caret beginning-match -----------------------------
 (defun helm-swoop--caret-match-delete ($o $aft $beg $end &optional $len)
+  "Caret match delete for $O, $AFT in $BEG to $END and $LEN."
   (if $aft
       (- $end $beg $len) ;; Unused argument? To avoid byte compile error
     (delete-region (overlay-start $o) (1- (overlay-end $o)))))
 
 (defun helm-swoop-caret-match (&optional _$resume)
+  "Caret match."
   (interactive)
   (let* (($prompt helm-swoop-prompt) ;; Accept change of the variable
          ($line-number-regexp "^[0-9]+.")
@@ -882,6 +908,7 @@ If $linum is number, lines are separated by $linum"
     $map))
 
 (defun helm-swoop--clear-edit-buffer ($prop)
+  "Clear edit buffer with $PROP."
   (let ((inhibit-read-only t))
     (mapc (lambda ($ov)
             (when (overlay-get $ov $prop)
@@ -892,7 +919,7 @@ If $linum is number, lines are separated by $linum"
     (erase-buffer)))
 
 (defun helm-swoop--collect-edited-lines ()
-  "Create a list of edited lines with each its own line number"
+  "Create a list of edited lines with each its own line number."
   (interactive)
   (let ($list)
     (goto-char (point-min))
@@ -911,7 +938,7 @@ If $linum is number, lines are separated by $linum"
     $list))
 
 (defun helm-swoop--edit ($candidate)
-  "This function will only be called from `helm-swoop-edit'"
+  "This function will only be called from `helm-swoop-edit' with $CANDIDATE."
   (interactive)
   (setq helm-swoop-edit-target-buffer helm-swoop-target-buffer)
   (delete-overlay helm-swoop-line-overlay)
@@ -954,8 +981,7 @@ If $linum is number, lines are separated by $linum"
                          (concat
                           " [\\<helm-swoop-edit-map>\\[helm-swoop--edit-complete]] Complete"
                           ", [\\<helm-swoop-edit-map>\\[helm-swoop--edit-cancel]] Cancel"
-                          ", [\\<helm-swoop-edit-map>\\[helm-swoop--edit-delete-all-lines]] Delete All"
-                          ))
+                          ", [\\<helm-swoop-edit-map>\\[helm-swoop--edit-delete-all-lines]] Delete All"))
                         'face 'helm-bookmark-addressbook)))
         ;; Line number and editable area
         (while (re-search-forward "^\\([0-9]+\s\\)\\(.*\\)$" nil t)
@@ -983,7 +1009,7 @@ If $linum is number, lines are separated by $linum"
   (use-local-map helm-swoop-edit-map))
 
 (defun helm-swoop--edit-complete ()
-  "Apply changes and kill temporary edit buffer"
+  "Apply change and kill temporary edit buffer."
   (interactive)
   (let (($list (helm-swoop--collect-edited-lines)))
     (with-current-buffer helm-swoop-edit-target-buffer
@@ -1002,7 +1028,7 @@ If $linum is number, lines are separated by $linum"
   (message "Successfully helm-swoop-edit applied to original buffer"))
 
 (defun helm-swoop--edit-delete-all-lines ()
-  "Apply changes and kill temporary edit buffer"
+  "Apply change and kill temporary edit buffer."
   (interactive)
   (let (($list (helm-swoop--collect-edited-lines)))
     (with-current-buffer helm-swoop-edit-target-buffer
@@ -1021,28 +1047,29 @@ If $linum is number, lines are separated by $linum"
   (message "Successfully helm-swoop-edit applied to original buffer"))
 
 (defun helm-swoop--edit-cancel ()
-  "Cancel edit and kill temporary buffer"
+  "Cancel edit and kill temporary buffer."
   (interactive)
   (select-window helm-swoop-synchronizing-window)
   (kill-buffer (get-buffer helm-swoop-edit-buffer))
   (message "helm-swoop-edit canceled"))
 
 (defun helm-swoop-edit ()
+  "Execute `helm-swoop--edit'."
   (interactive)
   (helm-exit-and-execute-action 'helm-swoop--edit))
 
 ;;; @ helm-multi-swoop ----------------------------------------
 (defvar helm-multi-swoop-buffer-list "*helm-multi-swoop buffers list*"
-  "Buffer name")
+  "Buffer name.")
 (defvar helm-multi-swoop-ignore-buffers-match "^\\*"
-  "Regexp to eliminate buffers you don't want to see")
+  "Regexp to eliminate buffers you don't want to see.")
 (defvar helm-multi-swoop-candidate-number-limit 250)
 (defvar helm-multi-swoop-last-selected-buffers nil)
 (defvar helm-multi-swoop-last-query nil)
 (defvar helm-multi-swoop-query nil)
 (defvar helm-multi-swoop-buffer "*Helm Multi Swoop*")
 (defvar helm-multi-swoop-all-from-helm-swoop-last-point nil
-  "For the last position, when helm-multi-swoop-all-from-helm-swoop canceled")
+  "For the last position, when helm-multi-swoop-all-from-helm-swoop canceled.")
 (defvar helm-multi-swoop-move-line-action-last-buffer nil)
 
 (defvar helm-multi-swoop-buffers-map
@@ -1058,6 +1085,7 @@ If $linum is number, lines are separated by $linum"
 ;; action -----------------------------------------------------
 
 (defun helm-multi-swoop--move-line-action ()
+  "Move line action."
   (with-helm-window
     (let* (($key (buffer-substring (point-at-bol) (point-at-eol)))
            ($num (when (string-match "^[0-9]+" $key)
@@ -1079,6 +1107,7 @@ If $linum is number, lines are separated by $linum"
         (setq helm-swoop-last-line-info (cons $buf $num))))))
 
 (defun helm-multi-swoop--get-marked-buffers ()
+  "Get marked buffers."
   (let ($list
         ($buf (get-buffer helm-multi-swoop-buffer-list)))
     (when $buf
@@ -1101,6 +1130,7 @@ If $linum is number, lines are separated by $linum"
 ;; core --------------------------------------------------------
 
 (cl-defun helm-multi-swoop--exec (ignored &key $query $buflist $func $action)
+  "Multi swoop exec with IGNORED $QUERY $BUFLIST $FUNC $ACTION."
   (interactive)
   (setq helm-swoop-synchronizing-window (selected-window))
   (setq helm-swoop-last-point
@@ -1205,6 +1235,7 @@ If $linum is number, lines are separated by $linum"
               $preserve-position)))))
 
 (defun helm-multi-swoop--get-buffer-list ()
+  "Get buffer list."
   (let ($buflist1 $buflist2)
     ;; eliminate buffers start with whitespace and dired buffers
     (mapc (lambda ($buf)
@@ -1223,7 +1254,7 @@ If $linum is number, lines are separated by $linum"
     $buflist2))
 
 (defun helm-c-source-helm-multi-swoop-buffers ()
-  "Show buffer list to select"
+  "Show buffer list to select."
   `((name . "helm-multi-swoop select buffers")
     (candidates . helm-multi-swoop--get-buffer-list)
     (header-line . "[C-SPC]/[M-SPC] select, [RET] next step")
@@ -1232,6 +1263,7 @@ If $linum is number, lines are separated by $linum"
     (search . ,(helm-swoop-search-functions))))
 
 (defun helm-multi-swoop--get-query ($query)
+  "Get query from $QUERY."
   (cond ($query
          (setq helm-multi-swoop-query $query))
         (mark-active
@@ -1248,16 +1280,16 @@ If $linum is number, lines are separated by $linum"
 
 ;;;###autoload
 (defun helm-multi-swoop (&optional $query $buflist)
-  "\
-Usage:
-M-x helm-multi-swoop
-1. Select any buffers by [C-SPC] or [M-SPC]
-2. Press [RET] to start helm-multi-swoop
+  "Multi swoop for $QUERY in $BUFLIST.
 
-C-u M-x helm-multi-swoop
+Usage:
+  \\[execute-extended-command] helm-multi-swoop
+  1. Select any buffers by [C-SPC] or [M-SPC]
+  2. Press [RET] to start `helm-multi-swoop'
+
+\\[universal-argument] \\[execute-extended-command] helm-multi-swoop
 If you have done helm-multi-swoop before, you can skip select buffers step.
-Last selected buffers will be applied to helm-multi-swoop.
-"
+Last selected buffers will be applied to helm-multi-swoop."
   (interactive)
   (setq helm-multi-swoop-query (helm-multi-swoop--get-query $query))
   (if (equal current-prefix-arg '(4))
@@ -1274,7 +1306,7 @@ Last selected buffers will be applied to helm-multi-swoop.
 
 ;;;###autoload
 (defun helm-multi-swoop-all (&optional $query)
-  "Apply all buffers to helm-multi-swoop"
+  "Apply all buffers to helm-multi-swoop for $QUERY."
   (interactive)
   (setq helm-multi-swoop-query (helm-multi-swoop--get-query $query))
   (helm-multi-swoop--exec nil
@@ -1282,7 +1314,7 @@ Last selected buffers will be applied to helm-multi-swoop.
                           :$buflist (helm-multi-swoop--get-buffer-list)))
 
 (defun get-buffers-matching-mode ($mode)
-  "Returns a list of buffers where their major-mode is equal to MODE"
+  "Return a list of buffers where their `major-mode' is equal to $MODE."
   (let ($buffer-mode-matches)
     (mapc (lambda ($buf)
             (when (get-buffer $buf)
@@ -1293,7 +1325,7 @@ Last selected buffers will be applied to helm-multi-swoop.
     $buffer-mode-matches))
 
 (defun helm-multi-swoop-by-mode ($mode &optional $query)
-  "Apply all buffers whose mode is MODE to helm-multi-swoop"
+  "Apply all buffers whose mode is $MODE to helm-multi-swoop for $QUERY."
   (setq helm-multi-swoop-query (helm-multi-swoop--get-query $query))
   (if (get-buffers-matching-mode $mode)
       (helm-multi-swoop--exec nil
@@ -1303,19 +1335,19 @@ Last selected buffers will be applied to helm-multi-swoop.
 
 ;;;###autoload
 (defun helm-multi-swoop-org (&optional $query)
-  "Applies all org-mode buffers to helm-multi-swoop"
+  "Applie all `org-mode' buffers to helm-multi-swoop for $QUERY."
   (interactive)
   (helm-multi-swoop-by-mode 'org-mode $query))
 
 ;;;###autoload
 (defun helm-multi-swoop-current-mode (&optional $query)
-  "Applies all buffers of the same mode as the current buffer to helm-multi-swoop"
+  "Applie all buffers of the same mode as the current buffer to helm-multi-swoop for $QUERY."
   (interactive)
   (helm-multi-swoop-by-mode major-mode $query))
 
 ;;;###autoload
 (defun helm-multi-swoop-projectile (&optional $query)
-  "Apply all opened buffers of the current project to helm-multi-swoop"
+  "Apply all opened buffers of the current project to helm-multi-swoop for $QUERY."
   (interactive)
   (setq helm-multi-swoop-query (helm-multi-swoop--get-query $query))
   (if (require 'projectile nil 'noerror)
@@ -1330,6 +1362,7 @@ Last selected buffers will be applied to helm-multi-swoop.
 
 
 (defun helm-swoop--wrap-function-with-pre-input-function ($target-func $pre-input-func)
+  "Wrap function with pre input function for $TARGET-FUNC and $PRE-INPUT-FUNC."
   (let ((helm-swoop-pre-input-function $pre-input-func))
     (funcall $target-func)))
 
@@ -1383,7 +1416,7 @@ Last selected buffers will be applied to helm-multi-swoop.
 ;; (define-key helm-swoop-map (kbd "M-m") 'helm-multi-swoop-current-mode-from-helm-swoop)
 
 (defadvice helm-resume (around helm-multi-swoop-resume activate)
-  "Resume if the last used helm buffer is *Helm Swoop*"
+  "Resume if the last used helm buffer is *Helm Swoop*."
   (if (equal helm-last-buffer helm-multi-swoop-buffer)
 
       (if (boundp 'helm-multi-swoop-last-query)
@@ -1396,7 +1429,7 @@ Last selected buffers will be applied to helm-multi-swoop.
 
 ;;; @ helm-multi-swoop-edit -----------------------------------
 (defvar helm-multi-swoop-edit-save t
-  "Save each buffer you edit when editing is complete")
+  "Save each buffer you edit when editing is complete.")
 (defvar helm-multi-swoop-edit-buffer "*Helm Multi Swoop Edit*")
 
 (defvar helm-multi-swoop-edit-map
@@ -1407,7 +1440,7 @@ Last selected buffers will be applied to helm-multi-swoop.
     $map))
 
 (defun helm-multi-swoop--edit ($candidate)
-  "This function will only be called from `helm-swoop-edit'"
+  "This function will only be called from `helm-swoop-edit' for $CANDIDATE."
   (interactive)
   (delete-overlay helm-swoop-line-overlay)
   (helm-swoop--delete-overlay 'target-buffer)
@@ -1468,8 +1501,7 @@ Last selected buffers will be applied to helm-multi-swoop.
                          (concat
                           " [\\<helm-swoop-edit-map>\\[helm-swoop--edit-complete]] Complete"
                           ", [\\<helm-swoop-edit-map>\\[helm-swoop--edit-cancel]] Cancel"
-                          ", [\\<helm-swoop-edit-map>\\[helm-swoop--edit-delete-all-lines]] Delete All"
-                          ))
+                          ", [\\<helm-swoop-edit-map>\\[helm-swoop--edit-delete-all-lines]] Delete All"))
                         'face 'helm-bookmark-addressbook)))
         ;; Line number and editable area
         (while (re-search-forward "^\\([0-9]+\s\\)\\(.*\\)$" nil t)
@@ -1500,6 +1532,7 @@ Last selected buffers will be applied to helm-multi-swoop.
   (use-local-map helm-multi-swoop-edit-map))
 
 (defun helm-multi-swoop--separate-text-property-into-list ($property)
+  "Separete text property into list for $PROPERTY."
   (interactive)
   (let ($list $end)
     (save-excursion
@@ -1518,7 +1551,7 @@ Last selected buffers will be applied to helm-multi-swoop.
     (nreverse $list)))
 
 (defun helm-multi-swoop--collect-edited-lines ()
-  "Create a list of edited lines with each its own line number"
+  "Create a list of edited lines with each its own line number."
   (interactive)
   (let* (($list
           (helm-multi-swoop--separate-text-property-into-list 'helm-header))
@@ -1550,7 +1583,7 @@ Last selected buffers will be applied to helm-multi-swoop.
     (delete '(nil) $pairs)))
 
 (defun helm-multi-swoop--edit-complete ()
-  "Delete all extracted lines, and apply changes to buffers and kill temporary edit buffer"
+  "Delete all extracted lines, and apply change to buffers and kill temporary edit buffer."
   (interactive)
   (let (($list (helm-multi-swoop--collect-edited-lines))
         $read-only)
@@ -1578,7 +1611,7 @@ Last selected buffers will be applied to helm-multi-swoop.
       (message "Successfully helm-multi-swoop-edit applied to original buffer"))))
 
 (defun helm-multi-swoop--edit-delete-all-lines ()
-  "Delete all extracted lines, and apply changes to buffers and kill temporary edit buffer"
+  "Delete all extracted lines, and apply change to buffers and kill temporary edit buffer."
   (interactive)
   (let (($list (helm-multi-swoop--collect-edited-lines))
         $read-only)
@@ -1606,7 +1639,7 @@ Last selected buffers will be applied to helm-multi-swoop.
       (message "Successfully helm-multi-swoop-edit applied to original buffer"))))
 
 (defun helm-multi-swoop--edit-cancel ()
-  "Cancel edit and kill temporary buffer"
+  "Cancel edit and kill temporary buffer."
   (interactive)
   (select-window helm-swoop-synchronizing-window)
   (kill-buffer (get-buffer helm-multi-swoop-edit-buffer))
@@ -1614,18 +1647,21 @@ Last selected buffers will be applied to helm-multi-swoop.
 
 ;;;###autoload
 (defun helm-multi-swoop-edit ()
+  "Multi swoop edit."
   (interactive)
   (helm-exit-and-execute-action 'helm-multi-swoop--edit))
 
 ;;; @ helm-swoop-same-face-at-point -----------------------------------
 
 (defsubst helm-swoop--get-at-face (&optional $point)
+  "Get at face at $POINT."
   (or $point (setq $point (point)))
   (let (($face (or (get-char-property $point 'read-face-name)
                    (get-char-property $point 'face))))
     $face))
 
 (defun helm-swoop--cull-face-include-line ($face)
+  "Cull face include line for $FACE."
   (let (($list) ($po (point-min)))
     (save-excursion
       (while (setq $po (next-single-property-change $po 'face))
@@ -1642,6 +1678,7 @@ Last selected buffers will be applied to helm-multi-swoop.
     (nreverse (delete-dups $list))))
 
 (defun helm-swoop-same-face-at-point (&optional $face)
+  "Same face at point for $FACE."
   (interactive)
   (or $face (setq $face (helm-swoop--get-at-face)))
   (helm-swoop :$query ""
@@ -1664,6 +1701,7 @@ Last selected buffers will be applied to helm-multi-swoop.
                     ("Edit" . helm-swoop--edit))))))
 
 (defun helm-multi-swoop-same-face-at-point (&optional $face)
+  "Same face at point for $FACE."
   (interactive)
   (or $face (setq $face (helm-swoop--get-at-face)))
   (helm-multi-swoop--exec


### PR DESCRIPTION
Fix package-lint/checkdoc/byte-compiler warnings.

Solves 84 warnings and 79 warnings remained.