### PR TITLE
Temporary workaround; not update candidate issue

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -654,7 +654,8 @@ If $LINUM is number, lines are separated by $LINUM."
               (> helm-swoop-last-prefix-number 1))
          '(multiline))
     (match . ,(helm-swoop-match-functions))
-    (search . ,(helm-swoop-search-functions))))
+    ;; (search . ,(helm-swoop-search-functions))
+    ))
 
 (defun helm-c-source-multi-swoop ($buf $func $action $multiline)
   "C source multi swoop in $BUF for $FUNC, $ACTION, $MULTILINE."
@@ -670,7 +671,8 @@ If $LINUM is number, lines are separated by $LINUM."
               (> $multiline 1))
          '(multiline))
     (match . ,(helm-swoop-match-functions))
-    (search . ,(helm-swoop-search-functions))))
+    ;; (search . ,(helm-swoop-search-functions))
+    ))
 
 (defun helm-swoop--set-prefix ($multiline)
   "Set prefix $MULTILINE."
@@ -1260,7 +1262,8 @@ If $LINUM is number, lines are separated by $LINUM."
     (header-line . "[C-SPC]/[M-SPC] select, [RET] next step")
     (keymap . ,helm-multi-swoop-buffers-map)
     (match . ,(helm-swoop-match-functions))
-    (search . ,(helm-swoop-search-functions))))
+    ;; (search . ,(helm-swoop-search-functions))
+    ))
 
 (defun helm-multi-swoop--get-query ($query)
   "Get query from $QUERY."


### PR DESCRIPTION
This reported at #175.
This caused by helm commit emacs-helm/helm@c09329c.
`helm--candidates-in-buffer-p` return value changed nil to t by that helm commit.