### PR TITLE
tagged v3.0.0; change depedency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - '24.4'
-          - '24.5'
           - '25.1'
           - '25.2'
           - '25.3'

--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -3,12 +3,12 @@
 ;; Copyright (C) 2019  Emacsorphanage Community
 ;; Copyright (C) 2013-2018  Shingo Fukuyama
 
-;; Version: 2.1.0
+;; Version: 3.0.0
 ;; Author: Shingo Fukuyama - http://fukuyama.co
 ;; URL: https://github.com/emacsorphanage/helm-swoop
 ;; Created: Oct 24 2013
 ;; Keywords: convenience, helm, swoop, inner, buffer, search
-;; Package-Requires: ((emacs "24.4") (helm "3.2"))
+;; Package-Requires: ((emacs "25.1") (helm "3.6"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2019  Emacsorphanage Community
 ;; Copyright (C) 2013-2018  Shingo Fukuyama
 
-;; Version: 2.0.0
+;; Version: 2.1.0
 ;; Author: Shingo Fukuyama - http://fukuyama.co
 ;; URL: https://github.com/emacsorphanage/helm-swoop
 ;; Created: Oct 24 2013


### PR DESCRIPTION
latest helm(v3.6.2) drop Emacs-24 support.
That makes helm-swoop also has to drop Emacs-24 support.

helm commit: https://github.com/emacs-helm/helm/commit/41242faebb5c16c23fe7e831d4bb2cb3294e074d