### PR TITLE
Remove key definition in the package loading.

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -809,7 +809,7 @@ If LINUM is number, lines are separated by LINUM."
       (isearch-exit))
     (helm-swoop :query query)))
 ;; When doing isearch, hand the word over to helm-swoop
-(define-key isearch-mode-map (kbd "M-i") 'helm-swoop-from-isearch)
+;; (define-key isearch-mode-map (kbd "M-i") 'helm-swoop-from-isearch)
 
 ;; Receive word from evil search ---------------
 (defun helm-swoop-from-evil-search ()


### PR DESCRIPTION
Avoid modification of Emacs behavior on the package loading.

In order to follow [the coding convention](https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html), disable key definition in the package loading
